### PR TITLE
ERVK Bkp reconstruction: infer orientation of inserted element

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 html
 releases
 test
+data
 *.pyc
 *~


### PR DESCRIPTION
Main changes in this PR:

- call different functions for orientation inference of insertions having polyA-tail (L1-like) and ERVK elements
- renamed existing function "insertion_orientation()" -> "insertion_orientation_polyA()"
- implemented new function "insertion_orientation_ERVK()": checks for 5'-informative and 3' informative contigs if
   - required alignments are set (5' target, 5' source, 3' target, 3' source) for present informative contigs
   - alignment orientation is the same in source and target regions (orientation "+") or
   - alignment orientations changes between target and source region (orientation "-")
   - 5'- and 3' informative contigs agree on orientation -> if not: orientation **inconsistent**

is_5prime_informative()
 - break loop after identifying source element aligment? or invest more work to identify best src alignment?
   (currently the last alignment with >50% overlap will be chosen, might affect inference of orientation for ERVK insertions)