### PR TITLE
Feature BAM2FASTA: Take BAM file as input, extract relevant reads during preprocessing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .gitignore
+apps
 html
 releases
 test

--- a/src/bash/extract_reads_bam2fa.sh
+++ b/src/bash/extract_reads_bam2fa.sh
@@ -8,30 +8,17 @@
 
 # Usage
 #########
+# bash extract_reads_bam2fa insertions.tsv sample.bam /path/to/outdir
 
 # Input
 ########
 # 1) TraFiC output file (TSV) containing insertion infos
 # 2) BAM read alignments
+# 3) output directory
 
 # Output
 #########
 # 1) FASTA file containing reads referenced in TraFiC insertions file.
-
-#### Script steps:
-
-## 4) Compress output to BAM
-#samtools view -S1 $outDir/targetReads.sam > $outDir/targetReads.bam
-
-# Input: $outDir/targetReads.sam
-# Output: $outDir/targetReads.bam
-
-## 5) Convert BAM to fasta
-# I think no option is needed..
-#samtools fasta [options] $outDir/targetReads.bam
-
-# Input: $outDir/targetReads.bam
-# Output: $outDir/targetReads.fasta
 
 scriptname=$(basename $0)
 

--- a/src/bash/extract_reads_bam2fa.sh
+++ b/src/bash/extract_reads_bam2fa.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+
+# Description
+##############
+# Extract reads overlapping insertion breakpoints from a BAM file.
+# Read IDs are collected from a TraFiC insertions file and corresponding
+# reads are output as FASTA (in order of appeareance in BAM).
+
+# Usage
+#########
+
+# Input
+########
+# 1) TraFiC output file (TSV) containing insertion infos
+# 2) BAM read alignments
+
+# Output
+#########
+# 1) FASTA file containing reads referenced in TraFiC insertions file.
+
+#### Script steps:
+
+## 4) Compress output to BAM
+#samtools view -S1 $outDir/targetReads.sam > $outDir/targetReads.bam
+
+# Input: $outDir/targetReads.sam
+# Output: $outDir/targetReads.bam
+
+## 5) Convert BAM to fasta
+# I think no option is needed..
+#samtools fasta [options] $outDir/targetReads.bam
+
+# Input: $outDir/targetReads.bam
+# Output: $outDir/targetReads.fasta
+
+scriptname=$(basename $0)
+
+function writeUsage {
+    echo "" &>2
+    echo "*** reads extractor ***" >&2
+    echo "usage: $scriptname trafic_insertions.tsv reads.bam out_dir" >&2
+    echo "" &>2
+}
+function writeError {
+    printf "[ERROR] ($scriptname) $1\n" >&2
+}
+function writeInfo {
+    printf "[INFO] ($scriptname) $1\n"
+}
+
+
+# Check input params
+if [[ $# < 3 ]]; then
+    writeUsage
+    exit -1
+elif [[ ! -f $1 ]]; then
+    writeError "file does not exist: $1"
+    exit -1
+elif [[ ! -f $2 ]]; then
+    writeError "file does not exist: $2"
+    exit -1
+elif [[ ! -d $3 ]]; then
+    writeError "directory does not exist: $3"
+    exit -1
+fi
+
+# get input/output options
+inInsertions=$1
+inBam=$2
+outDir=$3
+outSam=${outDir}/targetReads.sam
+outBam=${outDir}/targetReads.bam
+outTxt=${outDir}/readIDs.txt
+outFasta=${outDir}/targetReads.fasta
+
+writeInfo "reading read pair IDs from: $inInsertions"
+
+# get read IDs from TSV file (store them in memory) and extract reads from the BAM
+# conditions test the following:
+#   (NR==FNR):   Reading first file (insertions TSV)
+#   (!/^#/):     line does not start with '#' (e.g. headers, comments)
+#   (/^>/):      Reading FASTA header line
+#   (a[1] in r): part of FASTA header is in array r (stores read pair IDs)
+
+awkCmd='
+(NR==FNR) && (!/^#/) {
+    split($6","$12, a, ",");
+    for(x in a) r[a[x]];
+    next
+}
+(/^>/) {
+    split(substr($1,2), a, "/");
+    if (a[1] in r) {
+        print > outFasta;
+        getline;
+        print > outFasta
+        c++
+    }
+}
+END {
+    for (x in r) e++;
+    print "[INFO] ('$scriptname') reads expected:  "e*2
+    print "[INFO] ('$scriptname') reads extracted: "c
+}
+'
+awk -v outFasta=$outFasta "$awkCmd" \
+ $inInsertions \
+ <(samtools fasta $inBam)
+
+writeInfo "wrote output to: $outFasta"


### PR DESCRIPTION
ChangeLog:

 - new script: src/bash/extract_reads_bam2fasta.sh
 - new preliminary step 3): extract reads from BAM to $outDir/targetReads.fasta
 - changed parameter: "-f|--fasta" -> "-b|--bam"
 - changed to reflect parameter change: configuration info at start of pipeline
 - changed (now-)internal variable name: "$fasta" -> "$readsFasta"
 - extended "cleanupFunc" to delete "$outDir/targetReads.fasta"
